### PR TITLE
HOTFIX Sonar .tests e Sonar .testExecutionReportPaths comentados 

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,9 +5,9 @@ sonar.projectKey=Eccoar_2020.2-Eccoar_Mailer
 # in https://sonarcloud.io/documentation/project-administration/narrowing-the-focus/
 sonar.sources=./src
 sonar.host.url=https://sonarcloud.io
-#sonar.tests=./test
+sonar.tests=./test
 
 sonar.typescript.lcov.reportPaths=./coverage/lcov.info
-#sonar.testExecutionReportPaths=./test-report.xml
+sonar.testExecutionReportPaths=./test-report.xml
 
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Conteúdo
Descomenta as linhas sonar .tests e sonar .testExecutionReportPaths no arquivo sonar-project.properties para que as métricas tests e test_execution possam ser apropriadamente coletadas nos JSONs

Neste pull request se realizou:
- sonar-project.properties
